### PR TITLE
Quiet the logs and stop flooding

### DIFF
--- a/modules/stanford_related_courses/stanford_related_courses.module
+++ b/modules/stanford_related_courses/stanford_related_courses.module
@@ -30,8 +30,9 @@ function stanford_related_courses_alter_manage_courses(&$views) {
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_courses', "Display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_courses', "Display %display_name not available in view %view_name.", array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 

--- a/modules/stanford_related_events/stanford_related_events.module
+++ b/modules/stanford_related_events/stanford_related_events.module
@@ -51,8 +51,10 @@ function stanford_related_events_alter_manage_events(&$views) {
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_events', "Display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_events', "Display %display_name not available in view %view_name.",
+      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -81,8 +83,10 @@ function stanford_related_events_alter_upcoming_block(&$views) {
     $view = $views[$view_name];
   }
   else {
-    watchdog('stanford_related_events', "View '%name' not available.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_events', "View '%name' not available.",
       array('%name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -100,8 +104,10 @@ function stanford_related_events_alter_upcoming_block(&$views) {
     }
   }
   if ($page_handler == NULL) {
-    watchdog('stanford_related_events', "Display not available in view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_events', "Display not available in view %view_name.",
       array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -120,8 +126,10 @@ function stanford_related_events_alter_upcoming_block(&$views) {
 
   // Check that the view still works after we altered it!
   if (stanford_related_content_validate_view($views[$view_name], 'stanford_related_events')) {
-    watchdog('stanford_related_events', "Block 'filtered_upcoming_block' added to view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_events', "Block 'filtered_upcoming_block' added to view %view_name.",
       array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return TRUE;
   }
 

--- a/modules/stanford_related_news/stanford_related_news.module
+++ b/modules/stanford_related_news/stanford_related_news.module
@@ -33,8 +33,10 @@ function stanford_related_news_alter_manage_news(&$views) {
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_news', "Display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_news', "Display %display_name not available in view %view_name.",
+      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -104,8 +106,10 @@ function stanford_related_news_alter_3_item_block(&$views) {
   }
 
   if ($page_handler == null) {
-    watchdog('stanford_related_news', "Display not available in view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_news', "Display not available in view %view_name.",
       array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
   $page_path = $page_handler->get_option('path');
@@ -122,8 +126,10 @@ function stanford_related_news_alter_3_item_block(&$views) {
 
   // Check that the view still works after we altered it!
   if (stanford_related_content_validate_view($views[$view_name], 'stanford_related_news')) {
-    watchdog('stanford_related_news', "Block 'filtered_3_news_block' added to view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_news', "Block 'filtered_3_news_block' added to view %view_name.",
       array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return TRUE;
   }
   return FALSE;

--- a/modules/stanford_related_page/stanford_related_page.module
+++ b/modules/stanford_related_page/stanford_related_page.module
@@ -35,8 +35,10 @@ function stanford_related_page_alter_manage_page(&$views) {
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_page', "Display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_page', "Display %display_name not available in view %view_name.",
+      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 

--- a/modules/stanford_related_person/stanford_related_person.module
+++ b/modules/stanford_related_person/stanford_related_person.module
@@ -30,8 +30,10 @@ function stanford_related_person_alter_manage_person(&$views) {
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_person', "Display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_person', "Display %display_name not available in view %view_name.",
+      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -68,8 +70,10 @@ function stanford_related_person_alter_block(&$views) {
     $view = $views[$view_name];
   }
   else {
-    watchdog('stanford_related_person', "View '%name' not available.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_person', "View '%name' not available.",
       array('%name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -110,8 +114,10 @@ function stanford_related_person_alter_block(&$views) {
 
   // Check that the view still works after we altered it!
   if (stanford_related_content_validate_view($views[$view_name], 'stanford_related_person')) {
-    watchdog('stanford_related_person', "Block %display_name added to view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_person', "Block %display_name added to view %view_name.",
       array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return TRUE;
   }
   return FALSE;

--- a/modules/stanford_related_publication/stanford_related_publication.module
+++ b/modules/stanford_related_publication/stanford_related_publication.module
@@ -30,8 +30,10 @@ function stanford_related_publication_alter_manage_publication(&$views) {
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_publication', "Display %display_name not available in view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_publication', "Display %display_name not available in view %view_name.",
       array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    }
     return FALSE;
   }
 

--- a/stanford_related_content.module
+++ b/stanford_related_content.module
@@ -80,10 +80,12 @@ function stanford_related_content_validate_view($view, $name = 'stanford_related
     return TRUE;
   }
   else {
-    watchdog($name, "Could not validate view: %name (%title).",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog($name, "Could not validate view: %name (%title).",
       array('%name' => $view->name,
         '%title' => $view->get_title()),
-      WATCHDOG_NOTICE);
+      WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 }
@@ -108,8 +110,10 @@ function stanford_related_content_add_exposed_filter($views, $view_name, $displa
     $view = $views[$view_name];
   }
   else {
-    watchdog('stanford_related_content', "View %view_name not available.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "View %view_name not available.",
       array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -117,8 +121,10 @@ function stanford_related_content_add_exposed_filter($views, $view_name, $displa
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_content', "Display %display_name not available in view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Display %display_name not available in view %view_name.",
       array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -152,8 +158,10 @@ function stanford_related_content_add_exposed_filter($views, $view_name, $displa
 
   // Check that the view still works after we altered it!
   if (stanford_related_content_validate_view($views[$view_name], 'stanford_related_content')) {
-    watchdog('stanford_related_content', "Filter 'stanford_related_content' added to display %display_name on view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Filter 'stanford_related_content' added to display %display_name on view %view_name.",
       array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return TRUE;
   }
   else {
@@ -176,8 +184,10 @@ function stanford_related_content_add_vbo($views, $view_name, $display_name = 'p
     $view = $views[$view_name];
   }
   else {
-    watchdog('stanford_related_content', "View %view_name not available.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "View %view_name not available.",
       array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -185,8 +195,10 @@ function stanford_related_content_add_vbo($views, $view_name, $display_name = 'p
     $handler = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_content', "Display %display_name not available in view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Display %display_name not available in view %view_name.",
       array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -229,8 +241,10 @@ function stanford_related_content_add_vbo($views, $view_name, $display_name = 'p
 
   // Check that the view still works after we altered it!
   if (stanford_related_content_validate_view($views[$view_name], 'stanford_related_content')) {
-    watchdog('stanford_related_content', "Filter 'stanford_related_content' added to display %display_name on view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Filter 'stanford_related_content' added to display %display_name on view %view_name.",
       array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return TRUE;
   }
   else {
@@ -254,8 +268,10 @@ function stanford_related_content_copy_display($views, $view_name, $display_name
     $view = $views[$view_name];
   }
   else {
-    watchdog('stanford_related_content', "View '%view_name' not available.",
-      array('%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "View '%view_name' not available.",
+      array('%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -263,8 +279,10 @@ function stanford_related_content_copy_display($views, $view_name, $display_name
     $display_orig = $view->display_handler;
   }
   else {
-    watchdog('stanford_related_content', "Display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Display %display_name not available in view %view_name.",
+      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -279,8 +297,10 @@ function stanford_related_content_copy_display($views, $view_name, $display_name
     $options_orig = $display_orig->display->display_options;
   }
   else {
-    watchdog('stanford_related_content', "Display options for display %display_name not available in view %view_name.",
-      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Display options for display %display_name not available in view %view_name.",
+      array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -415,8 +435,10 @@ function stanford_related_content_insert_item($view, $display_id, $type, $table,
                                                 $after_field = NULL) {
 
   if (!$view->set_display($display_id)) {
-    watchdog('stanford_related_content', "Display %display_id not available in view %view_name.",
-      array('%display_id' => $display_id, '%view_name' => $view->name), WATCHDOG_NOTICE);
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+      watchdog('stanford_related_content', "Display %display_id not available in view %view_name.",
+      array('%display_id' => $display_id, '%view_name' => $view->name), WATCHDOG_DEBUG);
+    }
     return FALSE;
   }
 
@@ -483,8 +505,10 @@ function stanford_related_content_remove_display(&$views, $view_name, $display_n
     if (stanford_related_content_validate_view($view, $module_name)) {
       $view->save();
       views_flush_caches();
-      watchdog($module_name, "Display %display_name removed from view %view_name.",
+    if (varable_get("stanford_related_debug_mode", FALSE)) {
+        watchdog($module_name, "Display %display_name removed from view %view_name.",
         array('%display_name' => $display_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+      }
     }
   }
 }
@@ -516,8 +540,10 @@ function stanford_related_content_remove_filter(&$views, $view_name, $display_na
       // Check that the view still works after we altered it!
       if (stanford_related_content_validate_view($views[$view_name], $module_name)) {
         $view->save();
-        watchdog($module_name, "Filter %filter_name removed from view %view_name.",
+        if (varable_get("stanford_related_debug_mode", FALSE)) {
+          watchdog($module_name, "Filter %filter_name removed from view %view_name.",
           array('%filter_name' => $filter_name, '%view_name' => $view_name), WATCHDOG_DEBUG);
+        }
       }
     }
 


### PR DESCRIPTION
The watchdog logging of this module and sub modules is too aggressive to have running all of the time. I have wrapped the watchdog logs in a variable_get that can be toggled by a developer. It is off by default.
